### PR TITLE
Force a rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - so-versioning.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
The hope is that this will fix the issue with linking to libgcc_s.1.dylib on OS X, as alluded to here: https://github.com/conda-forge/scipy-feedstock/issues/59 . From my read of things, the current build was not made with the latest OSX gcc package.

The `conda inspect` output in the build logs should reveal whether the rebuild fixes the problem as hoped.