### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - so-versioning.patch
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
@@ -29,7 +29,7 @@ requirements:
     - cfitsio 3.410
     - cmake
     - fftw 3.3.*
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - ncurses 5.9*
     - openblas 0.2.19|0.2.19.*
     - readline 6.2*
@@ -37,7 +37,7 @@ requirements:
   run:
     - cfitsio 3.410
     - fftw 3.3.*
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - libgfortran  # [unix]
     - ncurses 5.9*
     - openblas 0.2.19|0.2.19.*


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71