### PR TITLE
Force a rebuild to use the newest numpy verion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - boost-python.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
I'm not sure if this is the correct approach, I just want the package to rebuild with the newest numpy version.