### PR TITLE
Update to Boost 1.64

### DIFF
--- a/recipe/boost-python3.patch
+++ b/recipe/boost-python3.patch
@@ -1,0 +1,17 @@
+--- a/casacore/python3/CMakeLists.txt	2017-06-02 14:20:42.513447648 -0400
++++ b/casacore/python3/CMakeLists.txt	2017-06-02 14:21:36.515767923 -0400
+@@ -23,13 +23,7 @@
+ find_package(Python REQUIRED)
+ 
+ if (PYTHONINTERP_FOUND)
+-    if (APPLE)
+-        find_package(Boost REQUIRED COMPONENTS python3)
+-    else ()
+-        # NOTE: the name of the python3 version of boost is probably Debian/Ubuntu specific
+-        find_package(Boost REQUIRED COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+-    endif (APPLE)
+-
++    find_package(Boost REQUIRED COMPONENTS python3)
+     find_package (NUMPY REQUIRED)
+ 
+     # copy the variables to their final destination

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - boost-python.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
@@ -27,7 +27,7 @@ requirements:
     - gcc  # [osx]
     - flex
     - bison
-    - boost 1.63.*  # note this is intentionally NOT the latest version; a bug in 1.64 breaks casa-tools
+    - boost 1.64.*
     - cfitsio 3.410
     - cmake
     - fftw 3.3.*
@@ -39,7 +39,7 @@ requirements:
     - readline 6.2*
     - wcslib 5.16
   run:
-    - boost 1.63.*  # note this is intentionally NOT the latest version; a bug in 1.64 breaks casa-tools
+    - boost 1.64.*
     - cfitsio 3.410
     - fftw 3.3.*
     - hdf5 1.8.18|1.8.18.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
     - ncursesw.patch
     - default-root.patch
     - so-versioning.patch
-    - boost-python.patch
+    - boost-python.patch  # [not py3k]
+    - boost-python3.patch  # [py3k]
 
 build:
   number: 1


### PR DESCRIPTION
casa-tools 5.0 no longer has the problem related to this version of Boost.