### PR TITLE
Unbreak Python matrixing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2
 
 jobs:
-  build:
+  build__CONDA_PY_27:
     working_directory: ~/test
     machine: true
+    environment:
+      - CONDA_PY: "27"
     steps:
       - checkout
       - run:
@@ -14,6 +16,52 @@ jobs:
       - run:
           command: docker pull condaforge/linux-anvil
       - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PY=${CONDA_PY}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
+  build__CONDA_PY_35:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PY: "35"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PY=${CONDA_PY}"
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
+  build__CONDA_PY_36:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONDA_PY: "36"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          name: Print conda-build environment variables
+          command: |
+            echo "CONDA_PY=${CONDA_PY}"
+      - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
 
@@ -21,4 +69,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build__CONDA_PY_27
+      - build__CONDA_PY_35
+      - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ os: osx
 osx_image: xcode6.4
 
 env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "lXbanRO2PIIkw6fon8O5NSRra6OLPlmsr7IUm5P2osi5DIBvuMllEcvtWqXUnQzcub0M1gGjBGOFSECPPaxI/ozq1IYrsGssSY73eOTG8pk9eaebThC06E5euGvFb5vGnzGFlFXY8escKAssUDfdRE33x6B6MCiohgt65xFLLPuNbqS37oUPRyTXVjBTvCh0c5vWsfkOApRmLzr1Dqeg1ISfu5x9s5xNxvcIYuiKYf0YdZjQzeiLeNRspLa09wpKfN6SNzCyKwo3hvH7l/nKMqYU/oHtY5ZkM8NkpsaT3CoffD0pBXTwzycQ8b26KhOFsRt0n0EJC+FNL73URqscGLt6f+tw5+GogQ0ojfD1lqQpRJhKML2edJnZcbT7WpXODV/WTtIWj8MfFlJp0SuSjCb7WTPYDusoxsyZgSljNjvK22cTFjoq7SNdtXssANBJuXXmw2sslZ+CWSpzD3JNkbQE2j2hQDPl7UMaRYtioxGQKuHpxaXEQPNtZWyLezcln4wMjKxV9EmfjWEoWxa2twL66WYC1L+qjAHARPRwybSzw7bU34Yt0D7nxScbaXOQg+joQspr6jDTNKDIfhUETMhGXHQEkFNTxnZOlnWU34s50DpNJqUKRFeC2g5YM4Cpbwq8oTANUDd8pb4/L3oeD+PhWhYVYW8jimh1svObBuY="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,6 +40,7 @@ cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
+                        -e CONDA_PY="${CONDA_PY}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - fftw 3.3.*
     - hdf5 1.10.1
     - ncurses 5.9
-    - numpy 1.7.*  # [py27]
+    - numpy 1.8.*  # [py27]
     - numpy 1.9.*  # [py35]
     - numpy 1.11.*  # [py36]
     - openblas 0.2.20|0.2.20.*
@@ -47,7 +47,7 @@ requirements:
     - hdf5 1.10.1
     - libgfortran  # [unix]
     - ncurses 5.9
-    - numpy >=1.7  # [py27]
+    - numpy >=1.8  # [py27]
     - numpy >=1.9  # [py35]
     - numpy >=1.11  # [py36]
     - openblas 0.2.20|0.2.20.*


### PR DESCRIPTION
Newest boost requires numpy 1.8 on Python 2.7. I'm not sure why that caused the Python 3.5 build to disappear too, but it's back now.