### PR TITLE
Hack CMake to ignore the "build environment" prefix in its searches

### DIFF
--- a/recipe/ignore-build-env-prefix.patch
+++ b/recipe/ignore-build-env-prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6bf9f4f..2eb980a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,6 +8,8 @@ include(CheckCXXCompilerFlag)
+ include(CheckCCompilerFlag)
+ include(CheckFunctionExists)
+ 
++list(FILTER CMAKE_SYSTEM_PREFIX_PATH EXCLUDE REGEX build_env)
++
+ # fixes warnings on cmake 3.x+ For now we want the old behavior to be backwards compatible
+ if (POLICY CMP0048)
+     cmake_policy (SET CMP0048 OLD)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ source:
     - default-root.patch
     - so-versioning.patch
     - boost-python.patch
+    - ignore-build-env-prefix.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
In [conda-forge GitHub issue #24](https://github.com/conda-forge/casacore-feedstock/issues/24) there was a problem because CMake decided to link with a version of the ncurses library found in the "build environment" prefix, rather than the "host environment" -- the major versions were different and so the resulting binaries did not link against the major version intended in the recipe specification.

As far as I can tell, the problem is that CMake decides that the "build environment" library directory should be searched for shared libraries, which is in turn because the build-env prefix shows up in the variable `CMAKE_SYSTEM_PREFIX_PATH`. We hack the CMakeLists.txt file to remove the relevant directory, which fixes the problem. As a bonus, a bunch of messages about libraries like `libz` being shadowed between the build and host prefixes now go away.

The [CMake docs](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PREFIX_PATH.html) say that you're not supposed to futz with this variable, but I couldn't find an alternative solution. It may be fixable by patching our cmake package -- although I don't have a good sense as to whether we might sometimes want the build-env prefix to be in `CMAKE_SYSTEM_PREFIX_PATH`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.
