### PR TITLE
Repin

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -13,7 +13,7 @@ docker_image:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 ncurses:
 - '6.1'
 numpy:

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -13,7 +13,7 @@ docker_image:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 ncurses:
 - '6.1'
 numpy:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -13,7 +13,7 @@ docker_image:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 ncurses:
 - '6.1'
 numpy:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 fortran_compiler:
 - toolchain_fort
 hdf5:
-- 1.10.3
+- 1.10.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "casacore" %}
-{% set version = "2.4.1" %}
+{% set version = "2.4.2a0" %}
 
 package:
   name: {{ name|lower }}
@@ -18,7 +18,7 @@ source:
     - ignore-build-env-prefix.patch
 
 build:
-  number: 6
+  number: 0
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('casacore', max_pin='x.x') }}


### PR DESCRIPTION
Blahhhhh. Need a build that (1) has the right API for CASA 4.5.1 and (2) links against HDF5 1.10.2, since 1.10.3 doesn't seem ready for prime-time. To make it easier to have downstream packages make sure they're getting the right version, I'm bumping to a fake prerelease version number.