### PR TITLE
Fix python-casacore on macOS/clang/Python3

### DIFF
--- a/recipe/clang-link.patch
+++ b/recipe/clang-link.patch
@@ -1,0 +1,28 @@
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index e2d0807b4..f78db3b11 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -66,7 +66,8 @@ Converters/PycRecord.cc
+ Converters/PycValueHolder.cc
+ )
+ 
+-target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${PYTHON2_LIBRARIES} ${CASACORE_ARCH_LIBS})
++target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${CASACORE_ARCH_LIBS})
++set_target_properties(casa_python PROPERTIES LINK_FLAGS "${LINK_FLAGS} -undefined dynamic_lookup")
+ 
+ install (TARGETS casa_python
+ RUNTIME DESTINATION bin
+diff --git a/python3/CMakeLists.txt b/python3/CMakeLists.txt
+index afc60e7c1..700cd669f 100644
+--- a/python3/CMakeLists.txt
++++ b/python3/CMakeLists.txt
+@@ -69,7 +69,8 @@ add_library (casa_python3
+ )
+ 
+ 
+-target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES} ${PYTHON3_LIBRARIES})
++target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES})
++set_target_properties(casa_python3 PROPERTIES LINK_FLAGS "${LINK_FLAGS} -undefined dynamic_lookup")
+ 
+ install (TARGETS casa_python3
+ RUNTIME DESTINATION bin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,10 @@ source:
     - so-versioning.patch
     - boost-python.patch
     - ignore-build-env-prefix.patch
+    - clang-link.patch  # [osx]
 
 build:
-  number: 1001
+  number: 1002
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('casacore', max_pin='x.x') }}


### PR DESCRIPTION
Something about the above-named combination of settings causes a subtle problem
in the libcasa_python3 library. See casacore/python-casacore#144 for the gory
details. Having the library not link with libpython, the way that Python
extension modules are built, seems to fix the problem.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
