### PR TITLE
Fix libcasa_python, again

### DIFF
--- a/recipe/clang-link.patch
+++ b/recipe/clang-link.patch
@@ -1,0 +1,28 @@
+diff --git a/python/CMakeLists-cmake3.14.txt b/python/CMakeLists-cmake3.14.txt
+index 7c981f7..8232051 100644
+--- a/python/CMakeLists-cmake3.14.txt
++++ b/python/CMakeLists-cmake3.14.txt
+@@ -60,7 +60,8 @@ Converters/PycValueHolder.h
+ Converters/PycArray.tcc
+ )
+ 
+-target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${PYTHON2_LIBRARIES} ${CASACORE_ARCH_LIBS})
++target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${CASACORE_ARCH_LIBS})
++set_target_properties(casa_python PROPERTIES LINK_FLAGS "${LINK_FLAGS} -undefined dynamic_lookup")
+ 
+ install (TARGETS casa_python
+ RUNTIME DESTINATION bin
+diff --git a/python3/CMakeLists-cmake3.14.txt b/python3/CMakeLists-cmake3.14.txt
+index 26d5ca5..3a9a084 100644
+--- a/python3/CMakeLists-cmake3.14.txt
++++ b/python3/CMakeLists-cmake3.14.txt
+@@ -51,7 +51,8 @@ add_library (casa_python3
+ )
+ 
+ 
+-target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES} ${PYTHON3_LIBRARIES})
++target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES})
++set_target_properties(casa_python3 PROPERTIES LINK_FLAGS "${LINK_FLAGS} -undefined dynamic_lookup")
+ 
+ install (TARGETS casa_python3
+ RUNTIME DESTINATION bin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
     - ncursesw.patch
     - default-root.patch
     - ignore-build-env-prefix.patch
+    - clang-link.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('casacore', max_pin='x.x') }}
@@ -56,6 +57,11 @@ test:
     - measuresdata
     - taql --help
     - tomf --help
+
+    # Make sure that libcasa_python doesn't link to libpython on macOS, since
+    # then the python-casacore modules will crash -- if binary modules on macOS
+    # link to libpython, symbols are duplicated.
+    - bash -c "! otool -L $PREFIX/lib/libcasa_python*.5.dylib |grep /libpython"  # [osx]
 
 about:
   home: https://casacore.github.io/casacore/


### PR DESCRIPTION
When updating for 3.3.0 I forgot that our clang-link patch was important for ensuring that python-casacore Python modules can load properly on macOS. Fix this again, and add a build-time test try to ensure that we don't mess this up again.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
