### PR TITLE
Manually migrate to add Python 3.11

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,36 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_mpinompinumpy1.20python3.8.____cpython:
-        CONFIG: linux_64_mpinompinumpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_mpinompinumpy1.20python3.9.____cpython:
-        CONFIG: linux_64_mpinompinumpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_mpinompinumpy1.21python3.10.____cpython:
         CONFIG: linux_64_mpinompinumpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_mpiopenmpinumpy1.20python3.8.____cpython:
-        CONFIG: linux_64_mpiopenmpinumpy1.20python3.8.____cpython
+      linux_64_mpinompinumpy1.21python3.8.____cpython:
+        CONFIG: linux_64_mpinompinumpy1.21python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_mpiopenmpinumpy1.20python3.9.____cpython:
-        CONFIG: linux_64_mpiopenmpinumpy1.20python3.9.____cpython
+      linux_64_mpinompinumpy1.21python3.9.____cpython:
+        CONFIG: linux_64_mpinompinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpinompinumpy1.23python3.11.____cpython:
+        CONFIG: linux_64_mpinompinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_mpiopenmpinumpy1.21python3.10.____cpython:
         CONFIG: linux_64_mpiopenmpinumpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpinumpy1.21python3.8.____cpython:
+        CONFIG: linux_64_mpiopenmpinumpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpinumpy1.21python3.9.____cpython:
+        CONFIG: linux_64_mpiopenmpinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_mpiopenmpinumpy1.23python3.11.____cpython:
+        CONFIG: linux_64_mpiopenmpinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,41 +8,53 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_mpinompinumpy1.20python3.8.____cpython:
-        CONFIG: osx_64_mpinompinumpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-      osx_64_mpinompinumpy1.20python3.9.____cpython:
-        CONFIG: osx_64_mpinompinumpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
       osx_64_mpinompinumpy1.21python3.10.____cpython:
         CONFIG: osx_64_mpinompinumpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_mpiopenmpinumpy1.20python3.8.____cpython:
-        CONFIG: osx_64_mpiopenmpinumpy1.20python3.8.____cpython
+      osx_64_mpinompinumpy1.21python3.8.____cpython:
+        CONFIG: osx_64_mpinompinumpy1.21python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_mpiopenmpinumpy1.20python3.9.____cpython:
-        CONFIG: osx_64_mpiopenmpinumpy1.20python3.9.____cpython
+      osx_64_mpinompinumpy1.21python3.9.____cpython:
+        CONFIG: osx_64_mpinompinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpinompinumpy1.23python3.11.____cpython:
+        CONFIG: osx_64_mpinompinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_64_mpiopenmpinumpy1.21python3.10.____cpython:
         CONFIG: osx_64_mpiopenmpinumpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpinompinumpy1.20python3.8.____cpython:
-        CONFIG: osx_arm64_mpinompinumpy1.20python3.8.____cpython
+      osx_64_mpiopenmpinumpy1.21python3.8.____cpython:
+        CONFIG: osx_64_mpiopenmpinumpy1.21python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpinompinumpy1.20python3.9.____cpython:
-        CONFIG: osx_arm64_mpinompinumpy1.20python3.9.____cpython
+      osx_64_mpiopenmpinumpy1.21python3.9.____cpython:
+        CONFIG: osx_64_mpiopenmpinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpinumpy1.23python3.11.____cpython:
+        CONFIG: osx_64_mpiopenmpinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_mpinompinumpy1.21python3.10.____cpython:
         CONFIG: osx_arm64_mpinompinumpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpiopenmpinumpy1.20python3.8.____cpython:
-        CONFIG: osx_arm64_mpiopenmpinumpy1.20python3.8.____cpython
+      osx_arm64_mpinompinumpy1.21python3.8.____cpython:
+        CONFIG: osx_arm64_mpinompinumpy1.21python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpiopenmpinumpy1.20python3.9.____cpython:
-        CONFIG: osx_arm64_mpiopenmpinumpy1.20python3.9.____cpython
+      osx_arm64_mpinompinumpy1.21python3.9.____cpython:
+        CONFIG: osx_arm64_mpinompinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpinompinumpy1.23python3.11.____cpython:
+        CONFIG: osx_arm64_mpinompinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython:
         CONFIG: osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython:
+        CONFIG: osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython:
+        CONFIG: osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython:
+        CONFIG: osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 cfitsio:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
@@ -23,7 +23,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 cfitsio:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
@@ -23,7 +23,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -35,13 +35,13 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 mpi:
-- openmpi
+- nompi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,7 +51,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,9 +13,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 fortran_compiler:
@@ -32,8 +34,6 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
 - nompi
 mpich:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 boost:
 - 1.78.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '14'
+- '12'
+cdt_name:
+- cos6
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,15 +13,17 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -32,16 +34,14 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
 mpi:
-- openmpi
+- nompi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-64
+- linux-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ boost:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 cfitsio:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
@@ -23,7 +23,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '14'
+- '12'
+cdt_name:
+- cos6
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,15 +13,17 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -32,16 +34,14 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -55,7 +55,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,9 +13,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 fortran_compiler:
@@ -32,10 +34,8 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,9 +13,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 fortran_compiler:
@@ -32,16 +34,14 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.21'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/migrations/hdf51122.yaml
+++ b/.ci_support/migrations/hdf51122.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.12.2
-migrator_ts: 1658944374.2290778

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.8.____cpython.yaml
@@ -1,11 +1,11 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 boost:
 - 1.78.0
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,17 +13,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -34,6 +32,8 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
 - nompi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -55,7 +55,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-64
+- osx-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,7 +51,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 boost:
 - 1.78.0
 c_compiler:
@@ -33,7 +33,7 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpi:
 - nompi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.21'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- osx-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 boost:
 - 1.78.0
 c_compiler:
@@ -33,9 +33,9 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.8.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- osx-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 boost:
 - 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -33,7 +33,7 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpi:
 - openmpi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -55,7 +55,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- osx-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 boost:
 - 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -33,7 +33,7 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpi:
 - openmpi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- osx-64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.21python3.8.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 boost:
 - 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -33,7 +33,7 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpi:
 - nompi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-64
+- osx-arm64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.21python3.9.____cpython.yaml
@@ -51,7 +51,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/osx_arm64_mpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 boost:
 - 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -33,15 +33,15 @@ libcblas:
 liblapack:
 - 3.9 *netlib
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpi:
-- openmpi
+- nompi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- osx-64
+- osx-arm64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -35,13 +35,13 @@ liblapack:
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,7 +51,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,17 +13,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -34,14 +32,16 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+macos_machine:
+- arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.21'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -55,7 +55,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-64
+- osx-arm64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -1,11 +1,11 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 boost:
 - 1.78.0
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,17 +13,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '15'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 gsl:
 - '2.7'
 hdf5:
@@ -34,6 +32,8 @@ libcblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+macos_machine:
+- arm64-apple-darwin20.0.0
 mpi:
 - openmpi
 mpich:
@@ -41,7 +41,7 @@ mpich:
 ncurses:
 - '6'
 numpy:
-- '1.20'
+- '1.23'
 openmpi:
 - '4'
 pin_run_as_build:
@@ -51,11 +51,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.11.* *_cpython
 readline:
 - '8'
 target_platform:
-- linux-64
+- osx-arm64
 wcslib:
 - '7.7'
 zip_keys:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About casacore
-==============
+About casacore-feedstock
+========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/casacore-feedstock/blob/main/LICENSE.txt)
 
 Home: https://casacore.github.io/casacore/
 
 Package license: GPL-2.0-or-later
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/casacore-feedstock/blob/main/LICENSE.txt)
 
 Summary: Core libraries for the Common Astronomical Software Applications (CASA)
 
@@ -27,20 +27,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_mpinompinumpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompinumpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_mpinompinumpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompinumpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_mpinompinumpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
@@ -48,17 +34,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpiopenmpinumpy1.20python3.8.____cpython</td>
+              <td>linux_64_mpinompinumpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpinumpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompinumpy1.21python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpiopenmpinumpy1.20python3.9.____cpython</td>
+              <td>linux_64_mpinompinumpy1.21python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpinumpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpinompinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -69,17 +62,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpinompinumpy1.20python3.8.____cpython</td>
+              <td>linux_64_mpiopenmpinumpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompinumpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpinumpy1.21python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpinompinumpy1.20python3.9.____cpython</td>
+              <td>linux_64_mpiopenmpinumpy1.21python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompinumpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_mpiopenmpinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -90,17 +90,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpiopenmpinumpy1.20python3.8.____cpython</td>
+              <td>osx_64_mpinompinumpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpinumpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompinumpy1.21python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpiopenmpinumpy1.20python3.9.____cpython</td>
+              <td>osx_64_mpinompinumpy1.21python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpinumpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpinompinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -111,17 +118,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpinompinumpy1.20python3.8.____cpython</td>
+              <td>osx_64_mpiopenmpinumpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompinumpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpinumpy1.21python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpinompinumpy1.20python3.9.____cpython</td>
+              <td>osx_64_mpiopenmpinumpy1.21python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompinumpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -132,17 +146,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpiopenmpinumpy1.20python3.8.____cpython</td>
+              <td>osx_arm64_mpinompinumpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompinumpy1.21python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpiopenmpinumpy1.20python3.9.____cpython</td>
+              <td>osx_arm64_mpinompinumpy1.21python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpinompinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -150,6 +171,27 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3791&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/casacore-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "casacore" %}
 {% set version = "3.5.0" %}
-{% set build = 4 %}
+{% set build = 5 %}
 {% set mpi = mpi or "nompi" %}
 
 {% if mpi == "nompi" %}
@@ -29,7 +29,7 @@ source:
 build:
   number: {{ build }}
   skip: true  # [win]
-  string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
+  string: {{ mpi_prefix }}_py{{ py }}h{{ PKG_HASH }}_{{ build }}
   run_exports:
     - {{ pin_subpackage('casacore', max_pin='x.x') }}
     - {{ name }} * {{ mpi_prefix }}_*  # [mpi != "nompi"]
@@ -64,13 +64,11 @@ requirements:
     - wcslib
     - libadios2 2.8 {{ mpi_prefix }}_*  # [mpi != "nompi"]
     - {{ mpi }}  # [mpi != "nompi"]
-    - mpifx * {{ mpi_prefix }}_*  # [mpi != "nompi"]
   run:
     - {{ pin_compatible('boost') }}
     - {{ pin_compatible('numpy') }}
     - python
     - {{ mpi }}  # [mpi != "nompi"]
-    - {{ pin_compatible('mpifx') }} {{ mpi_prefix }}_*  # [mpi != "nompi"]
 
 test:
   commands:


### PR DESCRIPTION
The bot-driven migration seems to be stuck due to the dependency on `mpifx` ... which, as far as I can tell, doesn't need to be a dependency for this package?

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
